### PR TITLE
Fix: prevent ClassCastException when non-player entities fire guns

### DIFF
--- a/src/main/java/net/marblednull/shotsfired/ModEvents.java
+++ b/src/main/java/net/marblednull/shotsfired/ModEvents.java
@@ -25,6 +25,7 @@ public class ModEvents {
 
     public static void spawnCasing(com.tacz.guns.api.event.common.GunFireEvent gunEvent, Item casingItem, double dropChance, String gunId) {
         //Create casing entity
+        if (!(gunEvent.getShooter() instanceof Player)) return;
 
         // Allow casing creation if this is true.
         // dropChance is thus the chance to spawn a casing.
@@ -59,7 +60,8 @@ public class ModEvents {
     public static void weaponShootEvent(com.tacz.guns.api.event.common.GunFireEvent gunEvent) {
         // TEMPORARY LOGGING STATEMENTS COMMENTED OUT BUT LEFT FOR WHEN/IF I REFACTOR
         if (gunEvent.getLogicalSide().isServer()) {
-           // LOGGER.warn("weaponShootEvent called");
+            if (!(gunEvent.getShooter() instanceof Player)) return;
+            // LOGGER.warn("weaponShootEvent called");
             Map<String, DropData> gunItemMap = TACZConfig.TACZ.get();
             // Get the GunId from the event
             String gunId = gunEvent.getGunItemStack().getTag().getString("GunId");

--- a/src/main/java/net/marblednull/shotsfired/ShotsFired.java
+++ b/src/main/java/net/marblednull/shotsfired/ShotsFired.java
@@ -2,7 +2,6 @@ package net.marblednull.shotsfired;
 
 import com.mojang.logging.LogUtils;
 
-import net.marblednull.shotsfired.config.TACZBurstConfig;
 import net.marblednull.shotsfired.config.TACZConfig;
 import net.marblednull.shotsfired.config.TACZEjectionConfig;
 import net.minecraftforge.api.distmarker.Dist;


### PR DESCRIPTION
# Fix ClassCastException when non-player entities fire guns

## Problem
When a non-player entity (such as [Touhou Little Maid](https://modrinth.com/mod/touhou-little-maid), EntityMaid) fires a TACZ gun, the mod throws a `ClassCastException` due to unsafe casting `(Player) gunEvent.getShooter()`. This exception propagates up the event chain and causes TACZ to cancel the shooting action entirely.

```
[222月2026 13:46:24.826] [Render thread/INFO] [net.minecraft.advancements.AdvancementList/]: Loaded 62 advancements
[222月2026 13:46:25.581] [Server thread/ERROR] [net.minecraftforge.eventbus.EventBus/EVENTBUS]: Exception caught during firing event: class com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid cannot be cast to class net.minecraft.world.entity.player.Player (com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid is in module touhou_little_maid@1.5.0-forge+mc1.20.1 of loader 'TRANSFORMER' @239f017e; net.minecraft.world.entity.player.Player is in module minecraft@1.20.1 of loader 'TRANSFORMER' @239f017e)
	Index: 1
	Listeners:
		0: NORMAL
		1: net.minecraftforge.eventbus.EventBus$$Lambda$4277/0x0000022681affc58@5ca0f428
		2: ASM: class com.tacz.guns.client.event.FirstPersonRenderGunEvent onGunFire(Lcom/tacz/guns/api/event/common/GunFireEvent;)V
		3: ASM: class com.tacz.guns.client.event.CameraSetupEvent initialCameraRecoil(Lcom/tacz/guns/api/event/common/GunFireEvent;)V
java.lang.ClassCastException: class com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid cannot be cast to class net.minecraft.world.entity.player.Player (com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid is in module touhou_little_maid@1.5.0-forge+mc1.20.1 of loader 'TRANSFORMER' @239f017e; net.minecraft.world.entity.player.Player is in module minecraft@1.20.1 of loader 'TRANSFORMER' @239f017e)
	at TRANSFORMER/shotsfired@1.20.1-0.2.2/net.marblednull.shotsfired.ModEvents.spawnCasing(ModEvents.java:47)
	at TRANSFORMER/shotsfired@1.20.1-0.2.2/net.marblednull.shotsfired.ModEvents.weaponShootEvent(ModEvents.java:74)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:260)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:252)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:315)
	at MC-BOOTSTRAP/net.minecraftforge.eventbus/net.minecraftforge.eventbus.EventBus.post(EventBus.java:296)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.item.ModernKineticGunScriptAPI.lambda$shootOnce$2(ModernKineticGunScriptAPI.java:155)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.util.CycleTaskHelper$CycleTaskTicker.tick(CycleTaskHelper.java:71)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.util.CycleTaskHelper.addCycleTask(CycleTaskHelper.java:20)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.item.ModernKineticGunScriptAPI.shootOnce(ModernKineticGunScriptAPI.java:145)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.item.ModernKineticGunItem.lambda$shoot$8(ModernKineticGunItem.java:117)
	at java.base/java.util.Optional.ifPresentOrElse(Optional.java:198)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.item.ModernKineticGunItem.shoot(ModernKineticGunItem.java:115)
	at TRANSFORMER/tacz@1.1.7-hotfix/com.tacz.guns.entity.shooter.LivingEntityShoot.shoot(LivingEntityShoot.java:141)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.LivingEntity.shoot(LivingEntity.java:4161)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.LivingEntity.shoot(LivingEntity.java:4155)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz.TacInnerCompat.performGunAttack(TacInnerCompat.java:87)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz.TacCompat.performGunAttack(TacCompat.java:75)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.common.GunCommonUtil.performGunAttack(GunCommonUtil.java:90)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.lambda$tick$0(GunShootTargetTask.java:68)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.tick(GunShootTargetTask.java:43)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.m_6725_(GunShootTargetTask.java:15)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.ai.behavior.Behavior.m_22558_(Behavior.java:66)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.ai.Brain.m_21963_(Brain.java:445)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.ai.Brain.m_21865_(Brain.java:390)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8024_(EntityMaid.java:515)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Mob.m_6140_(Mob.java:768)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.LivingEntity.m_8107_(LivingEntity.java:2548)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Mob.m_8107_(Mob.java:536)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.AgeableMob.m_8107_(AgeableMob.java:128)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.animal.Animal.m_8107_(Animal.java:54)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8107_(EntityMaid.java:619)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.LivingEntity.m_8119_(LivingEntity.java:2298)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Mob.m_8119_(Mob.java:337)
	at TRANSFORMER/touhou_little_maid@1.5.0-forge+mc1.20.1/com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8119_(EntityMaid.java:534)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:694)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.level.Level.m_46653_(Level.java:479)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:343)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:323)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.client.server.IntegratedServer.m_5705_(IntegratedServer.java:89)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661)
	at TRANSFORMER/minecraft@1.20.1/net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251)
	at java.base/java.lang.Thread.run(Thread.java:840)

[222月2026 13:46:25.583] [Server thread/ERROR] [touhou_little_maid/]: Error while performing gun attack for EntityMaid: 9938909a-f920-4d3a-88ce-bae9e1167ce3
java.lang.ClassCastException: class com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid cannot be cast to class net.minecraft.world.entity.player.Player (com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid is in module touhou_little_maid@1.5.0-forge+mc1.20.1 of loader 'TRANSFORMER' @239f017e; net.minecraft.world.entity.player.Player is in module minecraft@1.20.1 of loader 'TRANSFORMER' @239f017e)
	at net.marblednull.shotsfired.ModEvents.spawnCasing(ModEvents.java:47) ~[shotsfired-1.20.1-0.2.2.jar%23167!/:1.20.1-0.2.2]
	at net.marblednull.shotsfired.ModEvents.weaponShootEvent(ModEvents.java:74) ~[shotsfired-1.20.1-0.2.2.jar%23167!/:1.20.1-0.2.2]
	at net.minecraftforge.eventbus.EventBus.doCastFilter(EventBus.java:260) ~[eventbus-6.0.5.jar%23137!/:?]
	at net.minecraftforge.eventbus.EventBus.lambda$addListener$11(EventBus.java:252) ~[eventbus-6.0.5.jar%23137!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:315) ~[eventbus-6.0.5.jar%23137!/:?]
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:296) ~[eventbus-6.0.5.jar%23137!/:?]
	at com.tacz.guns.item.ModernKineticGunScriptAPI.lambda$shootOnce$2(ModernKineticGunScriptAPI.java:155) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at com.tacz.guns.util.CycleTaskHelper$CycleTaskTicker.tick(CycleTaskHelper.java:71) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at com.tacz.guns.util.CycleTaskHelper.addCycleTask(CycleTaskHelper.java:20) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at com.tacz.guns.item.ModernKineticGunScriptAPI.shootOnce(ModernKineticGunScriptAPI.java:145) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at com.tacz.guns.item.ModernKineticGunItem.lambda$shoot$8(ModernKineticGunItem.java:117) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at java.util.Optional.ifPresentOrElse(Optional.java:198) ~[?:?]
	at com.tacz.guns.item.ModernKineticGunItem.shoot(ModernKineticGunItem.java:115) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at com.tacz.guns.entity.shooter.LivingEntityShoot.shoot(LivingEntityShoot.java:141) ~[%5B永恒枪械工坊：零%5D%20tacz-1.20.1-1.1.7-hotfix.jar%23162!/:1.1.7-hotfix]
	at net.minecraft.world.entity.LivingEntity.shoot(LivingEntity.java:4161) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.LivingEntity.shoot(LivingEntity.java:4155) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz.TacInnerCompat.performGunAttack(TacInnerCompat.java:87) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.tacz.TacCompat.performGunAttack(TacCompat.java:75) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.common.GunCommonUtil.performGunAttack(GunCommonUtil.java:90) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.lambda$tick$0(GunShootTargetTask.java:68) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.tick(GunShootTargetTask.java:43) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at com.github.tartaricacid.touhoulittlemaid.compat.gun.common.ai.GunShootTargetTask.m_6725_(GunShootTargetTask.java:15) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at net.minecraft.world.entity.ai.behavior.Behavior.m_22558_(Behavior.java:66) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.ai.Brain.m_21963_(Brain.java:445) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.ai.Brain.m_21865_(Brain.java:390) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8024_(EntityMaid.java:515) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at net.minecraft.world.entity.Mob.m_6140_(Mob.java:768) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.LivingEntity.m_8107_(LivingEntity.java:2548) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.Mob.m_8107_(Mob.java:536) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.AgeableMob.m_8107_(AgeableMob.java:128) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.animal.Animal.m_8107_(Animal.java:54) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8107_(EntityMaid.java:619) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at net.minecraft.world.entity.LivingEntity.m_8119_(LivingEntity.java:2298) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.entity.Mob.m_8119_(Mob.java:337) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid.m_8119_(EntityMaid.java:534) ~[%5B车万女仆%5D%20touhoulittlemaid-1.5.0-forge+mc1.20.1-release.jar%23163!/:1.5.0-forge+mc1.20.1]
	at net.minecraft.server.level.ServerLevel.m_8647_(ServerLevel.java:694) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.level.Level.m_46653_(Level.java:479) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.level.ServerLevel.m_184063_(ServerLevel.java:343) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.world.level.entity.EntityTickList.m_156910_(EntityTickList.java:54) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.level.ServerLevel.m_8793_(ServerLevel.java:323) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.MinecraftServer.m_5703_(MinecraftServer.java:893) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.MinecraftServer.m_5705_(MinecraftServer.java:814) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.client.server.IntegratedServer.m_5705_(IntegratedServer.java:89) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.MinecraftServer.m_130011_(MinecraftServer.java:661) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at net.minecraft.server.MinecraftServer.m_206580_(MinecraftServer.java:251) ~[client-1.20.1-20230612.114412-srg.jar%23168!/:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]

```

https://github.com/user-attachments/assets/426935a8-84bd-4b15-b800-51daf7807a3c

## Root Cause
The code directly cast `gunEvent.getShooter()` to `Player` without verifying the type first. Since TACZ's `GunFireEvent` accepts any `LivingEntity` as the shooter, this causes an exception when non-player entities fire guns.

## Solution
This PR adds defensive type checks in both the `weaponShootEvent` method and the `spawnCasing` method to:
1. Check if `gunEvent.getShooter()` is an instance of `Player` before casting
2. Early return if the shooter is not a player, skipping casing drop logic
3. Maintain existing behavior for player shooters

https://github.com/user-attachments/assets/c0b7bbe3-b3e9-4e6b-ab59-6744ece4c450

## Changes
- Add `if (!(gunEvent.getShooter() instanceof Player)) return;` in `ModEvents.weaponShootEvent()`
- Add `if (!(gunEvent.getShooter() instanceof Player)) return;` in `ModEvents.spawnCasing()`
- Remove deprecated `TACZBurstConfig` import

---

While this PR resolves the immediate issue, it is a minimal fix.